### PR TITLE
app/publish: use in-memory locker on tus handler

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rs/cors"
 	"github.com/tus/tusd/pkg/filestore"
 	tusd "github.com/tus/tusd/pkg/handler"
+	"github.com/tus/tusd/pkg/memorylocker"
 )
 
 var logger = monitor.NewModuleLogger("api")
@@ -66,10 +67,11 @@ func InstallRoutes(r *mux.Router, sdkRouter *sdkrouter.Router) {
 	v2Router.HandleFunc("/status", emptyHandler).Methods(http.MethodOptions)
 
 	composer := tusd.NewStoreComposer()
-	store := filestore.FileStore{
-		Path: uploadPath,
-	}
+	store := filestore.New(uploadPath)
 	store.UseIn(composer)
+	locker := memorylocker.New()
+	locker.UseIn(composer)
+
 	tusCfg := tusd.Config{
 		BasePath:      "/api/v2/publish/",
 		StoreComposer: composer,

--- a/app/publish/tus.go
+++ b/app/publish/tus.go
@@ -172,11 +172,11 @@ func (h TusHandler) Notify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ignore the file name and rename the uploaded file to the new location
+	// rename the uploaded file to the new location
 	// with name based on the value from upload metadata.
-	dir, _ := filepath.Split(origUploadPath)
+	dir := filepath.Dir(origUploadPath)
 
-	dstDir := filepath.Join(dir, strconv.Itoa(user.ID))
+	dstDir := filepath.Join(dir, strconv.Itoa(user.ID), info.ID)
 	if err := os.MkdirAll(dstDir, os.ModePerm); err != nil {
 		log.WithError(err).Errorf("failed to create directory: %s", dstDir)
 		w.Write(rpcerrors.ErrorToJSON(err))


### PR DESCRIPTION
This is to protect read-write on tus file info against concurrrent
access. While at it add tus file id when renaming the file on notify
method to make sure the file is unique even for the same user

