### PR TITLE
app/publish: use filelocker

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
+	"github.com/tus/tusd/pkg/filelocker"
 	"github.com/tus/tusd/pkg/filestore"
 	tusd "github.com/tus/tusd/pkg/handler"
-	"github.com/tus/tusd/pkg/memorylocker"
 )
 
 var logger = monitor.NewModuleLogger("api")
@@ -69,7 +69,7 @@ func InstallRoutes(r *mux.Router, sdkRouter *sdkrouter.Router) {
 	composer := tusd.NewStoreComposer()
 	store := filestore.New(uploadPath)
 	store.UseIn(composer)
-	locker := memorylocker.New()
+	locker := filelocker.New(uploadPath)
 	locker.UseIn(composer)
 
 	tusCfg := tusd.Config{

--- a/app/publish/tus_test.go
+++ b/app/publish/tus_test.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/tus/tusd/pkg/filelocker"
 	"github.com/tus/tusd/pkg/filestore"
 	tusd "github.com/tus/tusd/pkg/handler"
-	"github.com/tus/tusd/pkg/memorylocker"
 )
 
 const tusVersion = "1.0.0"
@@ -33,7 +33,7 @@ func newTusTestCfg(uploadPath string) tusd.Config {
 	composer := tusd.NewStoreComposer()
 	store := filestore.New(uploadPath)
 	store.UseIn(composer)
-	locker := memorylocker.New()
+	locker := filelocker.New(uploadPath)
 	locker.UseIn(composer)
 	return tusd.Config{
 		BasePath:      "/api/v2/publish/",

--- a/go.sum
+++ b/go.sum
@@ -1288,6 +1288,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/Acconut/lockfile.v1 v1.1.0 h1:c5AMZOxgM1y+Zl8eSbaCENzVYp/LCaWosbQSXzb3FVI=
 gopkg.in/Acconut/lockfile.v1 v1.1.0/go.mod h1:6UCz3wJ8tSFUsPR6uP/j8uegEtDuEEqFxlpi0JI4Umw=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=


### PR DESCRIPTION
Because we run several instances of this server and we can't share the
lock using memory locker.

