### PR TITLE
Improve query cache

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -93,7 +93,10 @@ func InstallRoutes(r *mux.Router, sdkRouter *sdkrouter.Router) {
 }
 
 func defaultMiddlewares(rt *sdkrouter.Router, authProvider auth.Provider) mux.MiddlewareFunc {
-	memCache := cache.NewMemoryCache()
+	queryCache, err := cache.New(cache.DefaultConfig())
+	if err != nil {
+		panic(err)
+	}
 	defaultHeaders := []string{
 		wallet.TokenHeader, "X-Requested-With", "Content-Type", "Accept",
 	}
@@ -112,7 +115,7 @@ func defaultMiddlewares(rt *sdkrouter.Router, authProvider auth.Provider) mux.Mi
 		ip.Middleware,
 		sdkrouter.Middleware(rt),
 		auth.Middleware(authProvider),
-		cache.Middleware(memCache),
+		cache.Middleware(queryCache),
 	)
 }
 

--- a/app/proxy/proxy.go
+++ b/app/proxy/proxy.go
@@ -118,7 +118,7 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		sdkAddress = rt.RandomServer().Address
 	}
 
-	var qCache cache.QueryCache
+	var qCache *cache.Cache
 	if cache.IsOnRequest(r) {
 		qCache = cache.FromRequest(r)
 	}

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -162,7 +162,7 @@ retry:
 		}
 	}()
 
-	var qCache cache.QueryCache
+	var qCache *cache.Cache
 	if cache.IsOnRequest(r) {
 		qCache = cache.FromRequest(r)
 	}
@@ -207,7 +207,7 @@ retry:
 	observeSuccess(metrics.GetDuration(r))
 }
 
-func getCaller(sdkAddress, filename string, userID int, qCache cache.QueryCache) *query.Caller {
+func getCaller(sdkAddress, filename string, userID int, qCache *cache.Cache) *query.Caller {
 	c := query.NewCaller(sdkAddress, userID)
 	c.Cache = qCache
 	c.AddPreflightHook(query.AllMethodsHook, func(_ *query.Caller, hctx *query.HookContext) (*jsonrpc.RPCResponse, error) {

--- a/app/publish/tus.go
+++ b/app/publish/tus.go
@@ -193,7 +193,7 @@ func (h TusHandler) Notify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// upload is completed, notify it to lbrynet server
-	var qCache cache.QueryCache
+	var qCache *cache.Cache
 	if cache.IsOnRequest(r) {
 		qCache = cache.FromRequest(r)
 	}

--- a/app/query/cache/cache_test.go
+++ b/app/query/cache/cache_test.go
@@ -4,51 +4,57 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ybbus/jsonrpc"
 )
 
 func TestCache(t *testing.T) {
 	var (
-		response jsonrpc.RPCResponse
-		query    jsonrpc.RPCRequest
+		res jsonrpc.RPCResponse
+		req jsonrpc.RPCRequest
 	)
 
-	// params := map[string]interface{}{"urls": []string{"one", "two", "three"}}
-	rawQuery := `{"jsonrpc":"2.0","method":"resolve","params":{"urls":["one", "two", "three"]},"id":1555013448981}`
-	err := json.Unmarshal([]byte(rawQuery), &query)
+	rreq := `{"jsonrpc":"2.0","method":"resolve","params":{"urls":["one", "two", "three"]},"id":1555013448981}`
+	err := json.Unmarshal([]byte(rreq), &req)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	absPath, _ := filepath.Abs("./testdata/resolve_response.json")
-	rawJSON, err := ioutil.ReadFile(absPath)
+	rres, err := ioutil.ReadFile(absPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = json.Unmarshal(rawJSON, &response)
-	if err != nil {
-		t.Fatal(err)
+	err = json.Unmarshal(rres, &res)
+	require.NoError(t, err)
+
+	cfg := DefaultConfig()
+	cfg.ristrettoMetrics = true
+	c, err := New(cfg)
+	require.NoError(t, err)
+
+	retrievals := 0
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 500; i++ {
+		wg.Add(1)
+		go func() {
+			cached, err := c.Retrieve("resolve", req.Params, func() (interface{}, error) {
+				retrievals++
+				time.Sleep(500 * time.Millisecond)
+				return res, nil
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, res, cached)
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 
-	c := NewMemoryCache()
-	c.flush()
-	assert.Nil(t, c.Retrieve("resolve", query.Params))
-	c.Save("resolve", query.Params, response.Result)
-	assert.Equal(t, 1, c.Count())
-	assert.Equal(t, response.Result, c.Retrieve("resolve", query.Params))
-}
-
-func TestCacheGetKey(t *testing.T) {
-	c := NewMemoryCache()
-	c.flush()
-	key, err := c.getKey("resolve", map[string]interface{}{"urls": "one"})
-	assert.Equal(t, "resolve|3600a4eed065d3ae3dd503cca56ce56ae6bd4778047fa1b17c999301681d3a1d", key)
-	assert.NoError(t, err)
-
-	key, err = c.getKey("wallet_balance", nil)
-	assert.Equal(t, "wallet_balance|nil", key)
-	assert.NoError(t, err)
+	assert.EqualValues(t, 1, c.count())
+	assert.EqualValues(t, 1, retrievals)
 }

--- a/app/query/cache/middleware.go
+++ b/app/query/cache/middleware.go
@@ -13,21 +13,21 @@ func IsOnRequest(r *http.Request) bool {
 	return r.Context().Value(ContextKey) != nil
 }
 
-func FromRequest(r *http.Request) QueryCache {
+func FromRequest(r *http.Request) *Cache {
 	v := r.Context().Value(ContextKey)
 	if v == nil {
 		panic("cache.Middleware is required")
 	}
-	return v.(QueryCache)
+	return v.(*Cache)
 }
 
-func AddToRequest(c QueryCache, fn http.HandlerFunc) http.HandlerFunc {
+func AddToRequest(c *Cache, fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		fn(w, r.Clone(context.WithValue(r.Context(), ContextKey, c)))
 	}
 }
 
-func Middleware(c QueryCache) mux.MiddlewareFunc {
+func Middleware(c *Cache) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return AddToRequest(c, next.ServeHTTP)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/alecthomas/kong v0.2.16
 	github.com/bluele/factory-go v0.0.1
+	github.com/dgraph-io/ristretto v0.1.0
 	github.com/getsentry/sentry-go v0.6.1
 	github.com/gobuffalo/logger v1.0.3 // indirect
 	github.com/gobuffalo/packd v1.0.0 // indirect
@@ -50,6 +51,7 @@ require (
 	goa.design/plugins/v3 v3.4.3
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.6-0.20210802203754-9b21a8868e16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,11 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
+github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 h1:MGKhKyiYrvMDZsmLR/+RGffQSXwEkXgfLSA08qDn9AI=
@@ -159,6 +162,7 @@ github.com/dimfeld/httptreemux/v5 v5.3.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu9
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -346,6 +350,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"github.com/lbryio/lbrytv/apps/lbrytv/config"
 	"github.com/lbryio/lbrytv/version"
 
 	"github.com/sirupsen/logrus"
@@ -33,8 +34,7 @@ func init() {
 }
 
 func isProduction() bool {
-	// config.IsProduction()
-	return true
+	return config.IsProduction()
 }
 
 func LogMode() string {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -127,7 +127,7 @@ func GetStatusV2(w http.ResponseWriter, r *http.Request) {
 
 	var (
 		userID        int
-		qCache        cache.QueryCache
+		qCache        *cache.Cache
 		lbrynetServer *models.LbrynetServer
 	)
 	rt := sdkrouter.New(config.GetLbrynetServers())


### PR DESCRIPTION
The current JSON-RPC query result cache doesn't have any eviction mechanism and wasn't designed with high current load in mind. This adds a more sophisticated caching library, changes caching logic to do retrieval in one go instead of separate retrieve + save and adds protection against cache stampede.

Closes #394.