### PR TITLE
Patch publish call for stream_update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test
         run: |
-          go get -u github.com/jandelgado/gcov2lcov
+          go install github.com/jandelgado/gcov2lcov@latest
           go test -covermode=count -coverprofile=coverage.out ./... && gcov2lcov -infile=coverage.out -outfile=coverage.lcov
 
       - name: Coveralls GitHub Action

--- a/app/publish/handler_test.go
+++ b/app/publish/handler_test.go
@@ -80,7 +80,7 @@ func TestHandler_StreamUpdate(t *testing.T) {
 	expectedPath := path.Join(os.TempDir(), "20404", ".+", "lbry_auto_test_file")
 	assert.Regexp(t, expectedPath, publisher.queryParams["file_path"].(string))
 	assert.Equal(t, sdkrouter.WalletID(20404), publisher.queryParams["wallet_id"].(string))
-	assert.Empty(t, publisher.queryParams["name"].(string))
+	assert.NotContains(t, "name", publisher.queryParams)
 	assert.True(t, publisher.queryParams["replace"].(bool))
 	assert.Equal(t, "f6d2070225511eeb8a1c33f1d4bdb76e22716547", publisher.queryParams["claim_id"].(string))
 

--- a/app/publish/handler_test.go
+++ b/app/publish/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/lbryio/lbrytv/app/auth"
+	"github.com/lbryio/lbrytv/app/query"
 	"github.com/lbryio/lbrytv/app/sdkrouter"
 	"github.com/lbryio/lbrytv/app/wallet"
 	"github.com/lbryio/lbrytv/internal/test"
@@ -26,10 +27,65 @@ import (
 )
 
 type DummyPublisher struct {
-	called   bool
-	filePath string
-	walletID string
-	rawQuery string
+	called      bool
+	filePath    string
+	walletID    string
+	rawQuery    string
+	query       *jsonrpc.RPCRequest
+	queryParams map[string]interface{}
+}
+
+func TestHandler_StreamUpdate(t *testing.T) {
+	r := GenerateUpdateRequest(t, []byte("test file"))
+	r.Header.Set(wallet.TokenHeader, "uPldrToken")
+
+	publisher := &DummyPublisher{}
+
+	reqChan := test.ReqChan()
+	ts := test.MockHTTPServer(reqChan)
+	go func() {
+		req := <-reqChan
+		publisher.called = true
+		r := test.StrToReq(t, req.Body)
+		params, ok := r.Params.(map[string]interface{})
+		require.True(t, ok)
+		publisher.query = r
+		publisher.queryParams = params
+		ts.NextResponse <- expectedStreamCreateResponse
+	}()
+
+	handler := &Handler{UploadPath: os.TempDir()}
+
+	provider := func(token, _ string) (*models.User, error) {
+		var u *models.User
+		if token == "uPldrToken" {
+			u = &models.User{ID: 20404}
+			u.R = u.R.NewStruct()
+			u.R.LbrynetServer = &models.LbrynetServer{Address: ts.URL}
+		}
+		return u, nil
+	}
+
+	rr := httptest.NewRecorder()
+	auth.Middleware(provider)(http.HandlerFunc(handler.Handle)).ServeHTTP(rr, r)
+	response := rr.Result()
+	respBody, err := ioutil.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	test.AssertEqualJSON(t, expectedStreamCreateResponse, respBody)
+
+	require.True(t, publisher.called)
+	require.Equal(t, query.MethodStreamUpdate, publisher.query.Method)
+	expectedPath := path.Join(os.TempDir(), "20404", ".+", "lbry_auto_test_file")
+	assert.Regexp(t, expectedPath, publisher.queryParams["file_path"].(string))
+	assert.Equal(t, sdkrouter.WalletID(20404), publisher.queryParams["wallet_id"].(string))
+	assert.Empty(t, publisher.queryParams["name"].(string))
+	assert.True(t, publisher.queryParams["replace"].(bool))
+	assert.Equal(t, "f6d2070225511eeb8a1c33f1d4bdb76e22716547", publisher.queryParams["claim_id"].(string))
+
+	_, err = os.Stat(publisher.filePath)
+	assert.True(t, os.IsNotExist(err))
 }
 
 func TestUploadHandler(t *testing.T) {

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -35,8 +35,6 @@ var logger = monitor.NewModuleLogger("publish")
 var method = "publish"
 
 const (
-	FetchSizeLimit = 6000000000
-
 	// fileFieldName refers to the POST field containing file upload
 	fileFieldName = "file"
 	// jsonRPCFieldName is a name of the POST field containing JSONRPC request accompanying the uploaded file

--- a/app/publish/publish.go
+++ b/app/publish/publish.go
@@ -184,7 +184,7 @@ retry:
 	}
 	if params["claim_id"] != nil {
 		rpcReq.Method = query.MethodStreamUpdate
-		params["name"] = ""
+		delete(params, "name")
 		params["replace"] = true
 		rpcReq.Params = params
 	}

--- a/app/query/const.go
+++ b/app/query/const.go
@@ -4,25 +4,27 @@ const (
 	cacheResolveLongerThan = 10
 	maxListSizeLogged      = 5
 
-	MethodGet              = "get"
-	MethodFileList         = "file_list"
 	MethodAccountList      = "account_list"
-	MethodStatus           = "status"
-	MethodResolve          = "resolve"
 	MethodClaimSearch      = "claim_search"
+	MethodCommentReactList = "comment_react_list"
+	MethodFileList         = "file_list"
+	MethodGet              = "get"
+	MethodPublish          = "publish"
 	MethodPurchaseCreate   = "purchase_create"
+	MethodResolve          = "resolve"
+	MethodStatus           = "status"
+	MethodStreamUpdate     = "stream_update"
+	MethodSyncApply        = "sync_apply"
 	MethodWalletBalance    = "wallet_balance"
 	MethodWalletSend       = "wallet_send"
-	MethodSyncApply        = "sync_apply"
-	MethodCommentReactList = "comment_react_list"
 
-	ParamStreamingUrl    = "streaming_url"
-	ParamPurchaseReceipt = "purchase_receipt"
 	ParamAccountID       = "account_id"
-	ParamWalletID        = "wallet_id"
-	ParamUrls            = "urls"
-	ParamNewSDKServer    = "new_sdk_server"
 	ParamChannelID       = "channel_id"
+	ParamNewSDKServer    = "new_sdk_server"
+	ParamPurchaseReceipt = "purchase_receipt"
+	ParamStreamingUrl    = "streaming_url"
+	ParamUrls            = "urls"
+	ParamWalletID        = "wallet_id"
 )
 
 var forbiddenParams = []string{ParamAccountID, ParamNewSDKServer}
@@ -54,7 +56,7 @@ var walletSpecificMethods = []string{
 	"resolve",
 	"claim_search",
 
-	"publish",
+	MethodPublish,
 
 	"address_unused",
 	"address_list",
@@ -91,7 +93,7 @@ var walletSpecificMethods = []string{
 	"stream_abandon",
 	"stream_create",
 	"stream_list",
-	"stream_update",
+	MethodStreamUpdate,
 	"stream_repost",
 
 	"support_abandon",


### PR DESCRIPTION
When receiving a `publish` call containing `claim_id`:

- request method will be replaced with `stream_update`
- `name` param will be deleted
- `replace=true` will be added to params

Closes #399.

@tzarebczan please confirm this is the correct behavior.